### PR TITLE
Migrate to pyproject.toml + native uv project management

### DIFF
--- a/.github/workflows/new-repo-created.yml
+++ b/.github/workflows/new-repo-created.yml
@@ -113,7 +113,7 @@ jobs:
             # Commit the changes
             git config user.name github-actions[bot]
             git config user.email github-actions[bot]@users.noreply.github.com
-            git add CLAUDE.md CLAUDE.md
+            git add CLAUDE.md TEMPLATE_CLAUDE.md
             git commit -m "Create CLAUDE.md from template with repository information"
             git push
 


### PR DESCRIPTION
## Summary
- Migrated from `requirements.in` / `dev-requirements.in` / `pytest.ini` / `.ruff.toml` / `.coveragerc` to a unified `pyproject.toml` with native uv project management
- Added `uv.lock` for reproducible builds
- Fixed bug where `TEMPLATE_CLAUDE.md` was not deleted in new repos (duplicate `CLAUDE.md` in `git add` instead of staging `TEMPLATE_CLAUDE.md`)
- Updated justfile, Dockerfile, CLAUDE.md, and TEMPLATE_CLAUDE.md to reflect the new setup

## Test plan
- [ ] `just sync` installs all dependencies correctly
- [ ] `just lint` and `just test` work as expected
- [ ] `just build` and `just up` work with the updated Dockerfile
- [ ] Create a new repo from the template and verify `TEMPLATE_CLAUDE.md` is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)