### PR TITLE
Enforce Google Python style: strict docstrings, line length 100

### DIFF
--- a/TEMPLATE_AGENTS.md
+++ b/TEMPLATE_AGENTS.md
@@ -18,7 +18,8 @@ Bare `just` lists all commands. Add deps with `just add <pkg>` / `just add-dev <
 ## Stack
 
 - Python 3.13, managed by `uv` (`uv.lock` committed)
-- Lint/format: ruff — single quotes, line length 110, isort rules included
+- Style: Google Python Style Guide, strictly — overrides: single quotes, line length 100
+- Lint/format: ruff — enforces the above plus Google-convention docstrings (`D` rules: every public module/class/function needs one)
 - Tests: pytest, `asyncio_mode = auto` (no `@pytest.mark.asyncio` needed), coverage fails under 80%
 - Docker: `python:3.13-slim-bookworm`, non-root user, `src/` volume-mounted for hot reload
 
@@ -41,6 +42,7 @@ Rule: business logic lives only in `service.py` files. Transport files (routers,
 ## Rules
 
 - Type hints on all function signatures
+- Readability first: separate logical blocks with blank lines — after guard clauses, after setup, between distinct phases of a function
 - After every change run `just check`; fix until green before committing
 - Pre-commit hooks only scan `src/`; direct commits to main/master/develop are blocked
 - Never commit secrets; env vars go in `.env` (gitignored)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = []
 dev = ["pytest", "pytest-asyncio", "pytest-cov", "pre-commit", "ruff"]
 
 [tool.ruff]
-line-length = 110
+line-length = 100
 indent-width = 4
 exclude = [
     ".bzr",
@@ -64,11 +64,15 @@ select = [
     "B",
     "A",
     "C4",
+    "D",
 ]
 ignore = ["TD003"]
 fixable = ["ALL"]
 unfixable = []
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.isort]
 section-order = [

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Application source package."""

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,5 +1,8 @@
+"""Sanity check ensuring pytest collects at least one test in fresh repositories."""
+
 import src
 
 
 def test_sanity():
+    """Verify the src package is importable."""
     assert src is not None


### PR DESCRIPTION
Recovers commit that missed PR #56's merge window.

- ruff `D` rules + `convention = "google"` — docstrings mandatory on all public modules/classes/functions (tests included)
- Overrides vs Google: single quotes, line length 100 (was 110)
- TEMPLATE_AGENTS.md: documents style + blank-line readability rule
- Docstrings added to `src/__init__.py`, `tests/test_sanity.py`

Verified: `just check` green; negative test confirms D100/D103 fire on docstring-less code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)